### PR TITLE
No ~/Startify

### DIFF
--- a/autoload/startify.vim
+++ b/autoload/startify.vim
@@ -153,6 +153,7 @@ function! startify#insane_in_the_membrane() abort
 
   silent! file Startify
   set filetype=startify
+  set readonly
   if exists('#User#Startified')
     if v:version > 703 || v:version == 703 && has('patch442')
       doautocmd <nomodeline> User Startified


### PR DESCRIPTION
Sometimes you can accidentally press ZZ or :wq and save Startify buffer into file. I think it should be readonly because technically it should not be a real file at all.